### PR TITLE
add .env in .gitignore for improving the experience of python venv.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ logs/
 data/doc/
 data/test/
 .vscode/
+.env


### PR DESCRIPTION
".env" is commonly used in venv, which is an official python dependency management tool. This directory stores dependencies of this project. So It should be ignore when using venv.